### PR TITLE
feat: add docker compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Prevent copying node_modules and build artifacts
+node_modules
+app/node_modules
+app/build
+
+# Ignore git metadata
+.git
+.gitignore
+
+# Optional local files
+trades_for_database.csv
+*.csv
+
+# Exclude container config itself
+Dockerfile
+docker-compose.yaml
+k8s/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+# Install dependencies based on the package files
+COPY app/package.json app/package-lock.json ./
+RUN npm ci
+# Copy the rest of the application source
+COPY app/ .
+# Build the production bundle
+RUN npm run build
+
+# Production stage
+FROM nginx:1.25-alpine
+# Copy built assets from the build stage
+COPY --from=build /app/build /usr/share/nginx/html
+# Expose port 80 to allow binding by Docker / Kubernetes
+EXPOSE 80
+# Run nginx in foreground
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # TradeJournal-2
-# TradeJournal-2
+
+This repository contains a React-based trading journal application.
+
+## Docker usage
+
+Build the container image:
+
+```bash
+docker build -t tradejournal-app .
+```
+
+Run the application locally:
+
+```bash
+docker run -p 3000:80 tradejournal-app
+```
+
+Or use Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The app will be available at <http://localhost:8080>.
+
+## Kubernetes deployment
+
+A sample deployment is provided under `k8s/deployment.yaml`.
+After pushing your container image to a registry, deploy it with:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+```
+
+The service exposes the app on port 80 within the cluster.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tradejournal-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tradejournal-app
+  template:
+    metadata:
+      labels:
+        app: tradejournal-app
+    spec:
+      containers:
+        - name: tradejournal-app
+          image: tradejournal-app:latest
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tradejournal-service
+spec:
+  selector:
+    app: tradejournal-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary
- add docker-compose configuration for easier local development
- exclude compose file from Docker build context
- document using Docker Compose to run the app

## Testing
- `CI=true npm test -- --passWithNoTests`
- `python -m py_compile transform_trades.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdd05e137483288010a9b00bc76634