### PR TITLE
Refine hamburger menu interactions

### DIFF
--- a/app/src/components/ui/Header.jsx
+++ b/app/src/components/ui/Header.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Settings, Plus, LogIn, LogOut, User } from 'lucide-react';
+import React, { useState, useCallback } from 'react';
+import { Settings, Plus, LogIn, LogOut, User, Menu, X } from 'lucide-react';
 import AccountSelector from './AccountSelector';
 
 const Header = ({ 
@@ -17,70 +17,140 @@ const Header = ({
   onSignIn,
   onSignOut
 }) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const toggleMenu = () => setIsMenuOpen((prev) => !prev);
+  const closeMenu = useCallback(() => setIsMenuOpen(false), []);
+
+  const handleSelectAccount = (accountId) => {
+    onSelectAccount(accountId);
+    closeMenu();
+  };
+
+  const handleSignInClick = () => {
+    closeMenu();
+    onSignIn();
+  };
+
+  const handleSignOutClick = () => {
+    closeMenu();
+    onSignOut();
+  };
+
+  const handleToggleTradeForm = () => {
+    closeMenu();
+    onToggleTradeForm();
+  };
+
+  const handleToggleSettings = () => {
+    closeMenu();
+    onToggleSettings();
+  };
+
   return (
-    <div className="mb-8">
-      <div className="flex items-center justify-between">
+    <div className="mb-8 relative">
+      <div className="flex items-start justify-between gap-6">
         <div>
           <h1 className="text-4xl font-bold mb-2 bg-gradient-to-r from-blue-400 to-emerald-400 bg-clip-text text-transparent">
             Trading Journal
           </h1>
           <p className="text-gray-400">Track your trades and analyze your performance</p>
         </div>
-        
-        {/* Account Selector - positioned between title and action buttons */}
-        <div className="flex-1 flex justify-center">
-          <AccountSelector
-            accounts={accounts}
-            selectedAccountId={selectedAccountId}
-            onSelectAccount={onSelectAccount}
-            onAddAccount={onAddAccount}
-            onEditAccount={onEditAccount}
-            onDeleteAccount={onDeleteAccount}
-          />
-        </div>
-        
-        <div className="flex gap-4">
-          {isAuthenticated ? (
-            <>
-              {/* User info and sign out */}
-              <div className="flex items-center gap-3 px-4 py-2 bg-gray-700 rounded-lg">
-                <User className="h-4 w-4 text-gray-300" />
-                <span className="text-gray-300 text-sm">{user?.email}</span>
+
+        <div className="relative">
+          <button
+            type="button"
+            onClick={toggleMenu}
+            className="bg-gray-800 hover:bg-gray-700 p-3 rounded-xl transition-colors shadow-lg hover:shadow-xl"
+            aria-label="Toggle menu"
+            aria-expanded={isMenuOpen}
+          >
+            {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+
+          {isMenuOpen && (
+            <div className="absolute right-0 mt-4 w-80 bg-gray-900 border border-gray-700 rounded-2xl shadow-2xl p-5 space-y-5 z-50">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-white">Quick Actions</h2>
+                <button
+                  type="button"
+                  onClick={closeMenu}
+                  className="text-gray-400 hover:text-white transition-colors"
+                  aria-label="Close menu"
+                >
+                  <X className="h-5 w-5" />
+                </button>
               </div>
-              <button
-                onClick={onSignOut}
-                className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded-lg font-medium transition-colors flex items-center gap-2"
-              >
-                <LogOut className="h-4 w-4" />
-                Sign Out
-              </button>
-            </>
-          ) : (
-            <button
-              onClick={onSignIn}
-              className="bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 px-6 py-3 rounded-xl font-semibold transition-all duration-200 flex items-center gap-2 shadow-lg hover:shadow-xl"
-            >
-              <LogIn className="h-5 w-5" />
-              Sign In
-            </button>
+
+              <div className="space-y-3">
+                <p className="text-sm text-gray-400">Manage your accounts</p>
+                <AccountSelector
+                  accounts={accounts}
+                  selectedAccountId={selectedAccountId}
+                  onSelectAccount={handleSelectAccount}
+                  onAddAccount={onAddAccount}
+                  onEditAccount={onEditAccount}
+                  onDeleteAccount={onDeleteAccount}
+                />
+              </div>
+
+              <div className="space-y-3">
+                <p className="text-sm text-gray-400">Authentication</p>
+                {isAuthenticated ? (
+                  <>
+                    <div className="flex items-center gap-3 px-4 py-2 bg-gray-800 rounded-lg border border-gray-700">
+                      <User className="h-4 w-4 text-gray-300" />
+                      <span className="text-gray-300 text-sm truncate">{user?.email}</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleSignOutClick}
+                      className="w-full bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+                    >
+                      <LogOut className="h-4 w-4" />
+                      Sign Out
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleSignInClick}
+                    className="w-full bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 px-4 py-2 rounded-lg font-semibold transition-all duration-200 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl"
+                  >
+                    <LogIn className="h-5 w-5" />
+                    Sign In
+                  </button>
+                )}
+              </div>
+
+              <div className="space-y-3">
+                <p className="text-sm text-gray-400">Trading</p>
+                <button
+                  type="button"
+                  onClick={handleToggleTradeForm}
+                  aria-pressed={Boolean(showTradeForm)}
+                  className="w-full bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 px-4 py-2 rounded-lg font-semibold transition-all duration-200 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl"
+                >
+                  <Plus className="h-5 w-5" />
+                  {showTradeForm ? 'Hide Trade Form' : 'Add New Trade'}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleToggleSettings}
+                  className="w-full bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+                >
+                  <Settings className="h-4 w-4" />
+                  Settings
+                </button>
+              </div>
+            </div>
           )}
-          
-          <button
-            onClick={onToggleTradeForm}
-            className="bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 px-6 py-3 rounded-xl font-semibold transition-all duration-200 flex items-center gap-2 shadow-lg hover:shadow-xl"
-          >
-            <Plus className="h-5 w-5" />
-            {showTradeForm ? 'Cancel' : 'Add New Trade'}
-          </button>
-          <button
-            onClick={onToggleSettings}
-            className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded-lg font-medium transition-colors flex items-center gap-2"
-          >
-            <Settings className="h-4 w-4" />
-            Settings
-          </button>
         </div>
       </div>
+
+      {isMenuOpen && (
+        <div className="fixed inset-0 z-40" onClick={closeMenu} aria-hidden="true" />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- ensure hamburger menu actions close the overlay before invoking authentication, trading, and settings handlers
- add button semantics for menu items so sign-in and add-trade triggers reuse existing modals/forms outside of the menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e05a0caf148328bc111fe6cd711f43