### PR TITLE
Restrict trade creation and editing to authenticated users

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -87,7 +87,18 @@ function App() {
     };
   }, [trades, startingBalance, metrics.winningTrades, metrics.losingTrades, isAccountLoading, selectedAccountId]);
 
+  const ensureAuthenticated = () => {
+    if (!isAuthenticated) {
+      setShowSignInForm(true);
+      return false;
+    }
+    return true;
+  };
+
   const handleTradeSubmit = (tradeData) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     if (editingTrade) {
       updateTrade({ ...editingTrade, ...tradeData });
       clearEditingTrade();
@@ -101,11 +112,21 @@ function App() {
   };
 
   const handleTradeEdit = (trade) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     setEditingTrade(trade);
     // Only toggle trade form if we're on the main page (not viewing a trade)
     if (!viewingTrade) {
       toggleTradeForm();
     }
+  };
+
+  const handleToggleTradeForm = () => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
+    toggleTradeForm();
   };
 
   const handleTradeView = (trade) => {
@@ -185,13 +206,14 @@ function App() {
             onCancelEdit={() => {
               clearEditingTrade();
             }}
+            isAuthenticated={isAuthenticated}
           />
         ) : (
           // Main Dashboard View
           <>
             <Header
               onToggleSettings={toggleBalanceForm}
-              onToggleTradeForm={toggleTradeForm}
+              onToggleTradeForm={handleToggleTradeForm}
               showTradeForm={showTradeForm}
               accounts={accounts}
               selectedAccountId={selectedAccountId}

--- a/app/src/components/ui/Header.jsx
+++ b/app/src/components/ui/Header.jsx
@@ -125,15 +125,26 @@ const Header = ({
 
               <div className="space-y-3">
                 <p className="text-sm text-gray-400">Trading</p>
-                <button
-                  type="button"
-                  onClick={handleToggleTradeForm}
-                  aria-pressed={Boolean(showTradeForm)}
-                  className="w-full bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 px-4 py-2 rounded-lg font-semibold transition-all duration-200 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl"
-                >
-                  <Plus className="h-5 w-5" />
-                  {showTradeForm ? 'Hide Trade Form' : 'Add New Trade'}
-                </button>
+                {isAuthenticated ? (
+                  <button
+                    type="button"
+                    onClick={handleToggleTradeForm}
+                    aria-pressed={Boolean(showTradeForm)}
+                    className="w-full bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 px-4 py-2 rounded-lg font-semibold transition-all duration-200 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl"
+                  >
+                    <Plus className="h-5 w-5" />
+                    {showTradeForm ? 'Hide Trade Form' : 'Add New Trade'}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleSignInClick}
+                    className="w-full bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+                  >
+                    <LogIn className="h-4 w-4" />
+                    Sign in to add trades
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={handleToggleSettings}

--- a/app/src/components/ui/TradeDetailView.jsx
+++ b/app/src/components/ui/TradeDetailView.jsx
@@ -3,13 +3,14 @@ import { ArrowLeft, Edit, ExternalLink, Target, Calendar } from 'lucide-react';
 import { calculateTradeDuration, calculateReturnPercentage, getResultText, isWin, getTradeTypeText } from '../../utils/calculations';
 import TradeForm from '../forms/TradeForm';
 
-const TradeDetailView = ({ 
-  trade, 
-  onBack, 
-  onEdit, 
+const TradeDetailView = ({
+  trade,
+  onBack,
+  onEdit,
   isEditing,
   onSubmit,
-  onCancelEdit
+  onCancelEdit,
+  isAuthenticated
 }) => {
   if (!trade) return null;
 
@@ -35,7 +36,7 @@ const TradeDetailView = ({
             <p className="text-gray-400">Complete information for {trade.symbol} trade</p>
           </div>
           <div className="flex gap-4">
-            {!isEditing && (
+            {!isEditing && isAuthenticated && (
               <button
                 onClick={() => onEdit(trade)}
                 className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg font-medium transition-colors flex items-center gap-2"


### PR DESCRIPTION
## Summary
- require authentication before opening the trade form or submitting trade changes
- hide the add trade and edit trade controls for unauthenticated users while prompting them to sign in instead

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1ac93c4808328b651fe1b1834bc5a