### PR TITLE
Restrict trade and account management to authenticated users

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -87,7 +87,18 @@ function App() {
     };
   }, [trades, startingBalance, metrics.winningTrades, metrics.losingTrades, isAccountLoading, selectedAccountId]);
 
+  const ensureAuthenticated = () => {
+    if (!isAuthenticated) {
+      setShowSignInForm(true);
+      return false;
+    }
+    return true;
+  };
+
   const handleTradeSubmit = (tradeData) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     if (editingTrade) {
       updateTrade({ ...editingTrade, ...tradeData });
       clearEditingTrade();
@@ -101,11 +112,21 @@ function App() {
   };
 
   const handleTradeEdit = (trade) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     setEditingTrade(trade);
     // Only toggle trade form if we're on the main page (not viewing a trade)
     if (!viewingTrade) {
       toggleTradeForm();
     }
+  };
+
+  const handleToggleTradeForm = () => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
+    toggleTradeForm();
   };
 
   const handleTradeView = (trade) => {
@@ -123,27 +144,49 @@ function App() {
     toggleTradeForm();
   };
 
+  const handleToggleSettings = () => {
+    if (!showBalanceForm && !ensureAuthenticated()) {
+      return;
+    }
+    toggleBalanceForm();
+  };
+
   const handleUpdateBalance = (newBalance) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     updateStartingBalance(newBalance);
     toggleBalanceForm();
   };
 
   const handleAddAccount = (accountData) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     addAccount(accountData);
   };
 
   const handleEditAccount = (account) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     setEditingAccount(account);
     setShowAccountEditForm(true);
   };
 
   const handleAccountEditSubmit = (updatedAccount) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     updateAccount(updatedAccount);
     setShowAccountEditForm(false);
     setEditingAccount(null);
   };
 
   const handleDeleteAccount = (accountId) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
     if (accounts.length > 1) {
       deleteAccount(accountId);
     }
@@ -185,13 +228,14 @@ function App() {
             onCancelEdit={() => {
               clearEditingTrade();
             }}
+            isAuthenticated={isAuthenticated}
           />
         ) : (
           // Main Dashboard View
           <>
             <Header
-              onToggleSettings={toggleBalanceForm}
-              onToggleTradeForm={toggleTradeForm}
+              onToggleSettings={handleToggleSettings}
+              onToggleTradeForm={handleToggleTradeForm}
               showTradeForm={showTradeForm}
               accounts={accounts}
               selectedAccountId={selectedAccountId}
@@ -208,7 +252,7 @@ function App() {
             {/* Settings Form */}
             <SettingsForm
               isOpen={showBalanceForm}
-              onClose={toggleBalanceForm}
+              onClose={handleToggleSettings}
               onSubmit={handleUpdateBalance}
               currentBalance={startingBalance}
             />

--- a/app/src/components/ui/AccountSelector.jsx
+++ b/app/src/components/ui/AccountSelector.jsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
-import { ChevronDown, Plus, Settings, Trash2 } from 'lucide-react';
+import { ChevronDown, Plus, Settings, Trash2, LogIn } from 'lucide-react';
 
-const AccountSelector = ({ 
-  accounts, 
-  selectedAccountId, 
-  onSelectAccount, 
-  onAddAccount, 
-  onEditAccount, 
-  onDeleteAccount 
+const AccountSelector = ({
+  accounts,
+  selectedAccountId,
+  onSelectAccount,
+  onAddAccount,
+  onEditAccount,
+  onDeleteAccount,
+  isAuthenticated,
+  onSignIn
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [showAddForm, setShowAddForm] = useState(false);
@@ -16,8 +18,19 @@ const AccountSelector = ({
 
   const selectedAccount = accounts.find(acc => acc.id === selectedAccountId);
 
+  const handleRequireAuthentication = () => {
+    setIsOpen(false);
+    if (typeof onSignIn === 'function') {
+      onSignIn();
+    }
+  };
+
   const handleAddAccount = (e) => {
     e.preventDefault();
+    if (!isAuthenticated) {
+      handleRequireAuthentication();
+      return;
+    }
     if (newAccountName.trim() && newAccountBalance) {
       onAddAccount({
         name: newAccountName.trim(),
@@ -31,6 +44,10 @@ const AccountSelector = ({
   };
 
   const handleDeleteAccount = (accountId) => {
+    if (!isAuthenticated) {
+      handleRequireAuthentication();
+      return;
+    }
     if (accounts.length > 1) {
       onDeleteAccount(accountId);
       setIsOpen(false);
@@ -62,12 +79,14 @@ const AccountSelector = ({
                   Balance: ${selectedAccount?.currentBalance?.toLocaleString() || 0}
                 </p>
               </div>
-              <button
-                onClick={() => onEditAccount(selectedAccount)}
-                className="text-gray-400 hover:text-white transition-colors"
-              >
-                <Settings className="h-4 w-4" />
-              </button>
+              {isAuthenticated && (
+                <button
+                  onClick={() => onEditAccount(selectedAccount)}
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  <Settings className="h-4 w-4" />
+                </button>
+              )}
             </div>
           </div>
 
@@ -91,7 +110,7 @@ const AccountSelector = ({
                       ${account.currentBalance?.toLocaleString() || 0}
                     </div>
                   </div>
-                  {accounts.length > 1 && (
+                  {isAuthenticated && accounts.length > 1 && (
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
@@ -110,54 +129,68 @@ const AccountSelector = ({
 
           {/* Add New Account */}
           <div className="p-4 border-t border-gray-700">
-            {!showAddForm ? (
-              <button
-                onClick={() => setShowAddForm(true)}
-                className="w-full bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
-              >
-                <Plus className="h-4 w-4" />
-                Add New Account
-              </button>
+            {isAuthenticated ? (
+              !showAddForm ? (
+                <button
+                  onClick={() => setShowAddForm(true)}
+                  className="w-full bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+                >
+                  <Plus className="h-4 w-4" />
+                  Add New Account
+                </button>
+              ) : (
+                <form onSubmit={handleAddAccount} className="space-y-3">
+                  <input
+                    type="text"
+                    placeholder="Account Name"
+                    value={newAccountName}
+                    onChange={(e) => setNewAccountName(e.target.value)}
+                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
+                    required
+                  />
+                  <input
+                    type="number"
+                    placeholder="Starting Balance"
+                    value={newAccountBalance}
+                    onChange={(e) => setNewAccountBalance(e.target.value)}
+                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
+                    step="0.01"
+                    min="0"
+                    required
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      type="submit"
+                      className="flex-1 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+                    >
+                      Add
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setShowAddForm(false);
+                        setNewAccountName('');
+                        setNewAccountBalance('');
+                      }}
+                      className="flex-1 bg-gray-600 hover:bg-gray-500 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              )
             ) : (
-              <form onSubmit={handleAddAccount} className="space-y-3">
-                <input
-                  type="text"
-                  placeholder="Account Name"
-                  value={newAccountName}
-                  onChange={(e) => setNewAccountName(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
-                  required
-                />
-                <input
-                  type="number"
-                  placeholder="Starting Balance"
-                  value={newAccountBalance}
-                  onChange={(e) => setNewAccountBalance(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
-                  step="0.01"
-                  min="0"
-                  required
-                />
-                <div className="flex gap-2">
-                  <button
-                    type="submit"
-                    className="flex-1 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
-                  >
-                    Add
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShowAddForm(false);
-                      setNewAccountName('');
-                      setNewAccountBalance('');
-                    }}
-                    className="flex-1 bg-gray-600 hover:bg-gray-500 text-white px-4 py-2 rounded-lg font-medium transition-colors"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
+              <div className="space-y-3 text-center">
+                <p className="text-sm text-gray-400">Sign in to add or manage accounts.</p>
+                <button
+                  type="button"
+                  onClick={handleRequireAuthentication}
+                  className="w-full bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 text-white px-4 py-2 rounded-lg font-semibold transition-all duration-200 flex items-center justify-center gap-2"
+                >
+                  <LogIn className="h-4 w-4" />
+                  Sign In
+                </button>
+              </div>
             )}
           </div>
         </div>

--- a/app/src/components/ui/Header.jsx
+++ b/app/src/components/ui/Header.jsx
@@ -91,6 +91,8 @@ const Header = ({
                   onAddAccount={onAddAccount}
                   onEditAccount={onEditAccount}
                   onDeleteAccount={onDeleteAccount}
+                  isAuthenticated={isAuthenticated}
+                  onSignIn={handleSignInClick}
                 />
               </div>
 
@@ -125,23 +127,45 @@ const Header = ({
 
               <div className="space-y-3">
                 <p className="text-sm text-gray-400">Trading</p>
-                <button
-                  type="button"
-                  onClick={handleToggleTradeForm}
-                  aria-pressed={Boolean(showTradeForm)}
-                  className="w-full bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 px-4 py-2 rounded-lg font-semibold transition-all duration-200 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl"
-                >
-                  <Plus className="h-5 w-5" />
-                  {showTradeForm ? 'Hide Trade Form' : 'Add New Trade'}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleToggleSettings}
-                  className="w-full bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
-                >
-                  <Settings className="h-4 w-4" />
-                  Settings
-                </button>
+                {isAuthenticated ? (
+                  <button
+                    type="button"
+                    onClick={handleToggleTradeForm}
+                    aria-pressed={Boolean(showTradeForm)}
+                    className="w-full bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 px-4 py-2 rounded-lg font-semibold transition-all duration-200 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl"
+                  >
+                    <Plus className="h-5 w-5" />
+                    {showTradeForm ? 'Hide Trade Form' : 'Add New Trade'}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleSignInClick}
+                    className="w-full bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+                  >
+                    <LogIn className="h-4 w-4" />
+                    Sign in to add trades
+                  </button>
+                )}
+                {isAuthenticated ? (
+                  <button
+                    type="button"
+                    onClick={handleToggleSettings}
+                    className="w-full bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+                  >
+                    <Settings className="h-4 w-4" />
+                    Settings
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleSignInClick}
+                    className="w-full bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+                  >
+                    <Settings className="h-4 w-4" />
+                    Sign in to manage settings
+                  </button>
+                )}
               </div>
             </div>
           )}

--- a/app/src/components/ui/TradeDetailView.jsx
+++ b/app/src/components/ui/TradeDetailView.jsx
@@ -3,13 +3,14 @@ import { ArrowLeft, Edit, ExternalLink, Target, Calendar } from 'lucide-react';
 import { calculateTradeDuration, calculateReturnPercentage, getResultText, isWin, getTradeTypeText } from '../../utils/calculations';
 import TradeForm from '../forms/TradeForm';
 
-const TradeDetailView = ({ 
-  trade, 
-  onBack, 
-  onEdit, 
+const TradeDetailView = ({
+  trade,
+  onBack,
+  onEdit,
   isEditing,
   onSubmit,
-  onCancelEdit
+  onCancelEdit,
+  isAuthenticated
 }) => {
   if (!trade) return null;
 
@@ -35,7 +36,7 @@ const TradeDetailView = ({
             <p className="text-gray-400">Complete information for {trade.symbol} trade</p>
           </div>
           <div className="flex gap-4">
-            {!isEditing && (
+            {!isEditing && isAuthenticated && (
               <button
                 onClick={() => onEdit(trade)}
                 className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg font-medium transition-colors flex items-center gap-2"


### PR DESCRIPTION
## Summary
- require authentication before opening the trade form or submitting trade changes
- hide the add trade and edit trade controls for unauthenticated users while prompting them to sign in instead
- gate settings updates and account management actions behind authentication, surfacing sign-in prompts for guests attempting those actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1ac93c4808328b651fe1b1834bc5a