### PR TITLE
Refine header into Tailwind-inspired navbar

### DIFF
--- a/app/src/components/ui/Header.jsx
+++ b/app/src/components/ui/Header.jsx
@@ -100,8 +100,8 @@ const Header = ({
             ))}
           </div>
 
-          <div className="flex items-center gap-2 flex-1 justify-end">
-            <div className="w-full max-w-xs sm:max-w-sm md:max-w-md flex-shrink-0">
+          <div className="flex items-center gap-2">
+            <div className="hidden lg:block">
               <GlobalDateFilter />
             </div>
 
@@ -173,6 +173,11 @@ const Header = ({
               >
                 <X className="h-5 w-5" />
               </button>
+            </div>
+
+            <div className="space-y-3">
+              <p className="text-sm text-gray-400">Filter trades</p>
+              <GlobalDateFilter />
             </div>
 
             <div className="space-y-3">


### PR DESCRIPTION
## Summary
- restyle the header as a compact Tailwind-inspired navbar with branding and nav pills
- add quick action buttons and relocate the global date filter into both the navbar and profile menu
- refresh the profile menu with avatar styling and reorganized sections for filters, accounts, and trading actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69062d458a1c8328a25495786f254769