### PR TITLE
Revert "Expose global date filter beside mobile menu"

### DIFF
--- a/app/src/components/ui/Header.jsx
+++ b/app/src/components/ui/Header.jsx
@@ -100,8 +100,8 @@ const Header = ({
             ))}
           </div>
 
-          <div className="flex items-center gap-2 flex-1 justify-end">
-            <div className="w-full max-w-xs sm:max-w-sm md:max-w-md flex-shrink-0">
+          <div className="flex items-center gap-2">
+            <div className="hidden lg:block">
               <GlobalDateFilter />
             </div>
 
@@ -173,6 +173,11 @@ const Header = ({
               >
                 <X className="h-5 w-5" />
               </button>
+            </div>
+
+            <div className="space-y-3">
+              <p className="text-sm text-gray-400">Filter trades</p>
+              <GlobalDateFilter />
             </div>
 
             <div className="space-y-3">


### PR DESCRIPTION
## Summary
- revert the header layout change that surfaced the global date filter outside the mobile menu

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906377d83d0832883586b9516d52c82