### PR TITLE
Filter dashboard charts by exit date

### DIFF
--- a/app/src/components/views/DashboardView.jsx
+++ b/app/src/components/views/DashboardView.jsx
@@ -12,13 +12,13 @@ import {
   generateMonthlyNetPNLData,
   generateLast30DaysNetPNLData
 } from '../../utils/calculations';
-import { filterTradesByEntryDate, useDateFilter } from '../../context/DateFilterContext';
+import { filterTradesByExitDate, useDateFilter } from '../../context/DateFilterContext';
 
 const DashboardContent = ({ trades, startingBalance, onViewTrade }) => {
   const { filter } = useDateFilter();
 
   const filteredTrades = useMemo(() => {
-    return filterTradesByEntryDate(trades, filter);
+    return filterTradesByExitDate(trades, filter);
   }, [trades, filter]);
 
   const metrics = useMemo(() => {

--- a/app/src/context/DateFilterContext.jsx
+++ b/app/src/context/DateFilterContext.jsx
@@ -442,7 +442,7 @@ export const useDateFilter = () => {
   return context;
 };
 
-export const filterTradesByEntryDate = (trades, filter) => {
+export const filterTradesByExitDate = (trades, filter) => {
   if (!Array.isArray(trades) || trades.length === 0) {
     return [];
   }
@@ -455,20 +455,20 @@ export const filterTradesByEntryDate = (trades, filter) => {
   const toTime = filter.toUtc ? new Date(filter.toUtc).getTime() : null;
 
   return trades.filter((trade) => {
-    if (!trade || !trade.entry_date) {
+    if (!trade || !trade.exit_date) {
       return false;
     }
 
-    const entryTime = new Date(trade.entry_date).getTime();
-    if (Number.isNaN(entryTime)) {
+    const exitTime = new Date(trade.exit_date).getTime();
+    if (Number.isNaN(exitTime)) {
       return false;
     }
 
-    if (fromTime !== null && entryTime < fromTime) {
+    if (fromTime !== null && exitTime < fromTime) {
       return false;
     }
 
-    if (toTime !== null && entryTime > toTime) {
+    if (toTime !== null && exitTime > toTime) {
       return false;
     }
 

--- a/app/src/utils/calculations.js
+++ b/app/src/utils/calculations.js
@@ -60,15 +60,15 @@ export const generateCumulativeProfitData = (trades) => {
     return [];
   }
 
-  const tradesWithEntryDate = trades.filter((trade) => trade && trade.entry_date && !Number.isNaN(new Date(trade.entry_date).getTime()));
+  const tradesWithExitDate = trades.filter((trade) => trade && trade.exit_date && !Number.isNaN(new Date(trade.exit_date).getTime()));
 
-  if (tradesWithEntryDate.length === 0) {
+  if (tradesWithExitDate.length === 0) {
     return [];
   }
 
-  const sortedTrades = [...tradesWithEntryDate].sort((a, b) => {
-    const dateA = new Date(a.entry_date);
-    const dateB = new Date(b.entry_date);
+  const sortedTrades = [...tradesWithExitDate].sort((a, b) => {
+    const dateA = new Date(a.exit_date);
+    const dateB = new Date(b.exit_date);
     return dateA - dateB;
   });
 
@@ -78,7 +78,7 @@ export const generateCumulativeProfitData = (trades) => {
   sortedTrades.forEach((trade) => {
     cumulative += trade.profit || 0;
     data.push({
-      date: trade.entry_date,
+      date: trade.exit_date,
       cumulative: cumulative,
       profit: trade.profit
     });
@@ -89,15 +89,15 @@ export const generateCumulativeProfitData = (trades) => {
 
 // Generate chart data for account balance
 export const generateAccountBalanceData = (trades, startingBalance) => {
-  const tradesWithEntryDate = trades.filter((trade) => trade && trade.entry_date && !Number.isNaN(new Date(trade.entry_date).getTime()));
+  const tradesWithExitDate = trades.filter((trade) => trade && trade.exit_date && !Number.isNaN(new Date(trade.exit_date).getTime()));
 
-  if (tradesWithEntryDate.length === 0) {
+  if (tradesWithExitDate.length === 0) {
     return [{ date: 'Start', balance: startingBalance, tradeNum: 0 }];
   }
 
-  const sortedTrades = [...tradesWithEntryDate].sort((a, b) => {
-    const dateA = new Date(a.entry_date);
-    const dateB = new Date(b.entry_date);
+  const sortedTrades = [...tradesWithExitDate].sort((a, b) => {
+    const dateA = new Date(a.exit_date);
+    const dateB = new Date(b.exit_date);
     return dateA - dateB;
   });
 
@@ -108,7 +108,7 @@ export const generateAccountBalanceData = (trades, startingBalance) => {
     const profit = trade.profit || 0;
     balance += profit;
     data.push({
-      date: trade.entry_date,
+      date: trade.exit_date,
       balance,
       tradeNum: index + 1
     });
@@ -251,13 +251,13 @@ export const generateMonthlyNetPNLData = (trades) => {
   const monthlyData = {};
 
   trades.forEach((trade) => {
-    const entryDate = trade.entry_date ? new Date(trade.entry_date) : null;
-    if (!entryDate || isNaN(entryDate.getTime())) {
+    const exitDate = trade.exit_date ? new Date(trade.exit_date) : null;
+    if (!exitDate || isNaN(exitDate.getTime())) {
       return;
     }
 
-    const year = entryDate.getFullYear();
-    const month = entryDate.getMonth();
+    const year = exitDate.getFullYear();
+    const month = exitDate.getMonth();
     const monthKey = `${year}-${String(month + 1).padStart(2, '0')}`;
 
     if (!monthlyData[monthKey]) {


### PR DESCRIPTION
## Summary
- switch dashboard dashboard filtering to use each trade's exit date
- adjust cumulative profit, account balance, and monthly P&L data generation to rely on exit dates for ordering and labeling

## Testing
- npm run build *(fails: react-scripts: not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e63300ee08328ba32ee37cbd45f33)