### PR TITLE
Add symbol links to trade batch metrics cards

### DIFF
--- a/app/src/components/ui/BatchMetricsCard.jsx
+++ b/app/src/components/ui/BatchMetricsCard.jsx
@@ -61,21 +61,29 @@ const BatchMetricsCard = ({ title, subtitle, metrics, trades, onViewTrade }) => 
             <div className="flex justify-between items-start gap-4">
               <span className="text-sm text-gray-600 dark:text-gray-400 pt-1">Symbols</span>
               <div className="flex flex-wrap justify-end gap-2">
-                {trades.map((trade) => (
-                  <a
-                    key={trade.id}
-                    href="#"
-                    onClick={(event) => {
-                      event.preventDefault();
-                      if (onViewTrade) {
-                        onViewTrade(trade);
-                      }
-                    }}
-                    className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
-                  >
-                    {trade.symbol || '—'}
-                  </a>
-                ))}
+                {trades.map((trade) => {
+                  const isClickable = Boolean(onViewTrade);
+
+                  return (
+                    <button
+                      key={trade.id}
+                      type="button"
+                      onClick={() => {
+                        if (isClickable) {
+                          onViewTrade(trade);
+                        }
+                      }}
+                      className={`text-sm font-medium transition-colors ${
+                        isClickable
+                          ? 'text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300'
+                          : 'text-gray-500 dark:text-gray-400 cursor-default'
+                      }`}
+                      disabled={!isClickable}
+                    >
+                      {trade.symbol || '—'}
+                    </button>
+                  );
+                })}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- update the batch metrics card to accept the trade view handler
- render the symbols for the current batch as clickable links that open the trade detail view

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146e5640a483289f7faf381a43251c)