### PR TITLE
Split trade symbol links into winning and losing rows

### DIFF
--- a/app/src/components/ui/BatchMetricsCard.jsx
+++ b/app/src/components/ui/BatchMetricsCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const BatchMetricsCard = ({ title, subtitle, metrics, trades }) => {
+const BatchMetricsCard = ({ title, subtitle, metrics, trades, onViewTrade }) => {
   if (!metrics) {
     return (
       <div className="bg-white dark:bg-gray-800/50 backdrop-blur border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg hover:shadow-xl p-4 sm:p-6">
@@ -41,6 +41,38 @@ const BatchMetricsCard = ({ title, subtitle, metrics, trades }) => {
     return 'text-gray-600 dark:text-gray-400';
   };
 
+  const winningTradeLinks = trades?.filter((trade) => trade.profit > 0) || [];
+  const losingTradeLinks = trades?.filter((trade) => trade.profit < 0) || [];
+
+  const renderTradeLinks = (label, tradeList) => (
+    <div className="pb-3 border-b border-gray-200 dark:border-gray-700">
+      <div className="flex justify-between items-start gap-4">
+        <span className="text-sm text-gray-600 dark:text-gray-400 pt-1">{label}</span>
+        <div className="flex flex-wrap justify-end gap-2">
+          {tradeList.length > 0 ? (
+            tradeList.map((trade) => (
+              <a
+                key={trade.id}
+                href="#"
+                onClick={(event) => {
+                  event.preventDefault();
+                  if (onViewTrade) {
+                    onViewTrade(trade);
+                  }
+                }}
+                className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+              >
+                {trade.symbol || '—'}
+              </a>
+            ))
+          ) : (
+            <span className="text-sm text-gray-500 dark:text-gray-500">—</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <div className="bg-white dark:bg-gray-800/50 backdrop-blur border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg hover:shadow-xl p-4 sm:p-6">
       <div className="mb-4">
@@ -54,6 +86,12 @@ const BatchMetricsCard = ({ title, subtitle, metrics, trades }) => {
           <span className="text-sm text-gray-600 dark:text-gray-400">Total Trades</span>
           <span className="text-lg font-semibold text-gray-900 dark:text-white">{totalTrades}</span>
         </div>
+
+        {/* Winning Trade Symbols */}
+        {trades && trades.length > 0 && renderTradeLinks('Winning Trades', winningTradeLinks)}
+
+        {/* Losing Trade Symbols */}
+        {trades && trades.length > 0 && renderTradeLinks('Losing Trades', losingTradeLinks)}
 
         {/* Total Profit/Loss */}
         <div className="flex justify-between items-center pb-3 border-b border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- filter trades into winning and losing groups in the batch metrics card
- render separate rows of symbol links for winning and losing trades, falling back to em dashes when empty

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146e5640a483289f7faf381a43251c)