### PR TITLE
Prevent mobile zoom on tag filter search input

### DIFF
--- a/app/src/components/ui/GlobalTagFilter.jsx
+++ b/app/src/components/ui/GlobalTagFilter.jsx
@@ -119,7 +119,7 @@ const GlobalTagFilter = ({ variant = 'default' }) => {
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
                 placeholder="Search tags..."
-                className="w-full pl-8 pr-8 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                className="w-full pl-8 pr-8 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg text-base sm:text-sm text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
                 autoFocus
               />
               {searchQuery && (


### PR DESCRIPTION
## Summary
- keep the global tag filter search field at 16px on small screens to stop iOS from zooming the page when it gains focus

## Testing
- npm test -- --watchAll=false *(fails: No tests found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c1be30b08328b409fed138aa0777)