### PR TITLE
Add spacing to top of trade form

### DIFF
--- a/app/src/components/forms/TradeForm.jsx
+++ b/app/src/components/forms/TradeForm.jsx
@@ -99,7 +99,8 @@ const TradeForm = ({
   if (!isOpen) return null;
 
   return (
-    <div className="bg-white dark:bg-gray-800/50 backdrop-blur border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-8">
+    <div className="mt-32 max-w-7xl mx-auto px-4 sm:px-6">
+      <div className="bg-white dark:bg-gray-800/50 backdrop-blur border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-8">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-200">
           {editingTrade ? 'Edit Trade' : 'Add New Trade'}
@@ -309,6 +310,7 @@ const TradeForm = ({
         cancelText="Cancel"
         confirmButtonColor="bg-red-600 hover:bg-red-700"
       />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add a responsive outer container to `TradeForm` to introduce top spacing and centered layout.
> 
> - **UI/Layout**:
>   - In `app/src/components/forms/TradeForm.jsx`, wrap the form card in a responsive container `div` with `mt-32 max-w-7xl mx-auto px-4 sm:px-6` to add top spacing and center content.
>   - Adjust closing tags accordingly; no form logic changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d236411ffc34a9dd80d5efe4615136d1d863499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->