### PR TITLE
Preserve filters across navigation

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -247,24 +247,23 @@ function AppContent() {
     const showTagFilter = location.pathname === '/' || location.pathname === '/history';
 
     return (
-      <DateFilterProvider>
-        <TagFilterProvider>
-          <Header
-            onToggleSettings={handleToggleSettings}
-            onToggleTradeForm={handleToggleTradeForm}
-            showTradeForm={showTradeForm}
-            accounts={accounts}
-            selectedAccountId={selectedAccountId}
-            onSelectAccount={handleSelectAccount}
-            onAddAccount={handleAddAccount}
-            onEditAccount={handleEditAccount}
-            onDeleteAccount={handleDeleteAccount}
-            isAuthenticated={isAuthenticated}
-            user={user}
-            onSignIn={handleSignIn}
-            onSignOut={handleSignOut}
-            showTagFilter={showTagFilter}
-          />
+      <>
+        <Header
+          onToggleSettings={handleToggleSettings}
+          onToggleTradeForm={handleToggleTradeForm}
+          showTradeForm={showTradeForm}
+          accounts={accounts}
+          selectedAccountId={selectedAccountId}
+          onSelectAccount={handleSelectAccount}
+          onAddAccount={handleAddAccount}
+          onEditAccount={handleEditAccount}
+          onDeleteAccount={handleDeleteAccount}
+          isAuthenticated={isAuthenticated}
+          user={user}
+          onSignIn={handleSignIn}
+          onSignOut={handleSignOut}
+          showTagFilter={showTagFilter}
+        />
 
       {/* Settings Form */}
       <SettingsForm
@@ -325,12 +324,11 @@ function AppContent() {
         )}
         
         {/* Bottom Navigation Dock - only visible on main routes */}
-        <BottomNavDock 
+        <BottomNavDock
           onToggleTradeForm={handleToggleTradeForm}
           showTradeForm={showTradeForm}
         />
-        </TagFilterProvider>
-      </DateFilterProvider>
+      </>
     );
   };
 
@@ -400,11 +398,15 @@ function AppContent() {
 function App() {
   return (
     <ThemeProvider>
-      <BrowserRouter>
-        <AppContent />
-        <SpeedInsights />
-        <Analytics />
-      </BrowserRouter>
+      <DateFilterProvider>
+        <TagFilterProvider>
+          <BrowserRouter>
+            <AppContent />
+            <SpeedInsights />
+            <Analytics />
+          </BrowserRouter>
+        </TagFilterProvider>
+      </DateFilterProvider>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the application in shared date and tag filter providers so selections persist while moving between routes
- maintain the existing layout while preventing per-page remounting of filter state

## Testing
- CI=true npm test -- --runInBand (fails: no tests found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fa612a2388328813e7b1d97e11ef2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move `DateFilterProvider` and `TagFilterProvider` to wrap `BrowserRouter`, removing per-page providers so filter state persists across navigation.
> 
> - **App structure**:
>   - Hoist `DateFilterProvider` and `TagFilterProvider` to wrap `BrowserRouter` in `App`, removing them from `MainLayout` to persist filter state across routes.
>   - Keep `Header`, forms, and `BottomNavDock` within `MainLayout` using a fragment wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf8997140a2a30708741356aeb90035524dd39dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->